### PR TITLE
Turtle output: as useful for HAMAP as SPARQL 

### DIFF
--- a/src/C/include/pfProfile.h
+++ b/src/C/include/pfProfile.h
@@ -649,6 +649,10 @@ PFIMPEXP void PrintOneLine( const struct Profile * const prf, const char * * con
 														const struct Alignment * const alignment, char * const Header,
 														const size_t SequenceLength, const float RAVE, const int N, const PrintInput_t * const extra);
 
+PFIMPEXP void PrintTurtle( const struct Profile * const prf, const char * * const AlignedSequence,
+														const struct Alignment * const alignment, char * const Header,
+														const size_t SequenceLength, const float RAVE, const int N, const PrintInput_t * const extra);
+
 PFIMPEXP void PrintSAM(const struct Profile * const prf, const char * * const AlignedSequence,
 											 const struct Alignment * const alignment, char * const Header,
 											 const size_t SequenceLength, const float RAVE, const int N, const PrintInput_t * const extra);

--- a/src/C/prg/pfscan.c
+++ b/src/C/prg/pfscan.c
@@ -1007,10 +1007,13 @@ int main (int argc, char *argv[])
                 printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns>\n");
                 printf("PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\n");
                 printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
-                printf("PREFIX signature:<htp://purl.uniprot.org/hamap/>\n");
                 printf("PREFIX edam:<http://edamontology.org/>\n");
-                printf("PREFIX profile:<http://example.org/yourprofiledb>\n");
-                printf("PREFIX hamap:<https://hamap.expasy.org/rdf/>\n");
+                if (strstr(ProfileFile, "hamap") > 0) {
+                    printf("PREFIX profile:<http://purl.uniprot.org/hamap/>\n");
+                } else {
+                    printf("PREFIX profile:<http://example.org/yourprofiledb>\n");
+                }
+                
             }
 
       /* Initialize the print mutex */

--- a/src/C/prg/pfscan.c
+++ b/src/C/prg/pfscan.c
@@ -1000,7 +1000,17 @@ int main (int argc, char *argv[])
 					printf("@SQ\tSN:%.*s|%s\tLN:%zu\tDS:%s\n",
 							 	 AClen, prf->AC_Number, prf->Identification, prf->Length, prf->Description);
 				}
-			}
+			} else if (PrintFunction == &PrintTurtle) {
+                printf("PREFIX ys:<http://example.org/yoursequence/>\n");
+                printf("PREFIX yr:<http://example.org/yourrecord/>\n");
+                printf("PREFIX up:<http://purl.uniprot.org/core/>\n");
+                printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns>\n");
+                printf("PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\n");
+                printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
+                printf("PREFIX signature:<htp://purl.uniprot.org/hamap/>\n");
+                printf("PREFIX edam:<http://edamontology.org/>\n");
+                printf("PREFIX hamap:<http://hamap.expasy.org/rdf/>\n");
+            }
 
       /* Initialize the print mutex */
       pthread_mutex_init(&PrintLock, NULL);

--- a/src/C/prg/pfscan.c
+++ b/src/C/prg/pfscan.c
@@ -1004,7 +1004,7 @@ int main (int argc, char *argv[])
                 printf("PREFIX ys:<http://example.org/yoursequence/>\n");
                 printf("PREFIX yr:<http://example.org/yourrecord/>\n");
                 printf("PREFIX up:<http://purl.uniprot.org/core/>\n");
-                printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns>\n");
+                printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n");
                 printf("PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\n");
                 printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
                 printf("PREFIX edam:<http://edamontology.org/>\n");

--- a/src/C/prg/pfscan.c
+++ b/src/C/prg/pfscan.c
@@ -1009,7 +1009,8 @@ int main (int argc, char *argv[])
                 printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
                 printf("PREFIX signature:<htp://purl.uniprot.org/hamap/>\n");
                 printf("PREFIX edam:<http://edamontology.org/>\n");
-                printf("PREFIX hamap:<http://hamap.expasy.org/rdf/>\n");
+                printf("PREFIX profile:<http://example.org/yourprofiledb>\n");
+                printf("PREFIX hamap:<https://hamap.expasy.org/rdf/>\n");
             }
 
       /* Initialize the print mutex */

--- a/src/C/prg/pfscan.c
+++ b/src/C/prg/pfscan.c
@@ -141,7 +141,8 @@ static void __attribute__((noreturn)) Usage(FILE * stream)
 		"                                     == 5 Pfscan long\n"
     "                                     == 6 xPSA output\n"
 		"                                     == 7 tsv output (single line tab delimited)\n"
-		"                                     == 8 SAM output\n",
+		"                                     == 8 SAM output\n"
+		"                                     == 9 Turtle/RDF output\n",
 		stream);
 	fprintf(stream,
     "   --output-length <uint>     [-W] : maximum number of column for sequence\n"
@@ -285,7 +286,8 @@ int main (int argc, char *argv[])
 						case 6: PrintFunction = &PrintxPSA; break;
 						case 7: PrintFunction = &PrintTSV; break;
 						case 8: PrintFunction = &PrintSAM; break;
-						case 9: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
+                        case 9: PrintFunction = &PrintTurtle; break;
+						case 10: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
 						default:
 							fputs("Unrecognized ouput method.\n", stderr);
 							exit(1);

--- a/src/C/prg/pfscan.c
+++ b/src/C/prg/pfscan.c
@@ -142,7 +142,8 @@ static void __attribute__((noreturn)) Usage(FILE * stream)
     "                                     == 6 xPSA output\n"
 		"                                     == 7 tsv output (single line tab delimited)\n"
 		"                                     == 8 SAM output\n"
-		"                                     == 9 Turtle/RDF output\n",
+		"                                     == 9 Print a classification\n"
+		"                                     == 10 Turtle/RDF output\n",
 		stream);
 	fprintf(stream,
     "   --output-length <uint>     [-W] : maximum number of column for sequence\n"
@@ -286,8 +287,8 @@ int main (int argc, char *argv[])
 						case 6: PrintFunction = &PrintxPSA; break;
 						case 7: PrintFunction = &PrintTSV; break;
 						case 8: PrintFunction = &PrintSAM; break;
-                        case 9: PrintFunction = &PrintTurtle; break;
-						case 10: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
+						case 9: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
+                        case 10: PrintFunction = &PrintTurtle; break;
 						default:
 							fputs("Unrecognized ouput method.\n", stderr);
 							exit(1);

--- a/src/C/prg/pfsearch.c
+++ b/src/C/prg/pfsearch.c
@@ -1545,10 +1545,13 @@ int main (int argc, char *argv[])
             printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns>\n");
             printf("PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\n");
             printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
-            printf("PREFIX signature:<htp://purl.uniprot.org/hamap/>\n");
             printf("PREFIX edam:<http://edamontology.org/>\n");
             printf("PREFIX profile:<http://example.org/yourprofiledb/>\n");
-            printf("PREFIX hamap:<https://hamap.expasy.org/rdf/>\n");
+            if (strstr(ProfileFile, "MF_") > 0) { // this is very likely to be a hamap sequence
+                printf("PREFIX profile:<http://purl.uniprot.org/hamap/>\n");
+            } else {
+                printf("PREFIX profile:<http://example.org/yourprofiledb>\n");
+            }
         }
 
 

--- a/src/C/prg/pfsearch.c
+++ b/src/C/prg/pfsearch.c
@@ -1538,7 +1538,18 @@ int main (int argc, char *argv[])
 			printf("@HD\tVN:1.6\tSO:coordinate\n"
 				     "@SQ\tSN:%.*s|%s\tLN:%zu\tDS:%s\n",
 					   AClen, prf->AC_Number, prf->Identification, prf->Length, prf->Description);
-		}
+		} else if (PrintFunction == &PrintTurtle) {
+            printf("PREFIX ys:<http://example.org/yoursequence/>\n");
+            printf("PREFIX yr:<http://example.org/yourrecord/>\n)");
+            printf("PREFIX up:<http://purl.uniprot.org/core/>\n");
+            printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns>\n");
+            printf("PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\n");
+            printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
+            printf("PREFIX signature:<htp://purl.uniprot.org/hamap/>\n");
+            printf("PREFIX edam:<http://edamontology.org/>\n");
+            printf("PREFIX hamap:<http://hamap.expasy.org/rdf/>\n");
+        }
+
 
 		/* Initialize the print mutex */
 #if !defined(__USE_WINAPI__)

--- a/src/C/prg/pfsearch.c
+++ b/src/C/prg/pfsearch.c
@@ -1542,7 +1542,7 @@ int main (int argc, char *argv[])
             printf("PREFIX ys:<http://example.org/yoursequence/>\n");
             printf("PREFIX yr:<http://example.org/yourrecord/>\n)");
             printf("PREFIX up:<http://purl.uniprot.org/core/>\n");
-            printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns>\n");
+            printf("PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n");
             printf("PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\n");
             printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
             printf("PREFIX edam:<http://edamontology.org/>\n");

--- a/src/C/prg/pfsearch.c
+++ b/src/C/prg/pfsearch.c
@@ -179,7 +179,8 @@ static void __attribute__((noreturn)) Usage(FILE * stream)
     "                                     == 6 xPSA output\n"
 		"                                     == 7 tsv output (single line tab delimited)\n"
 		"                                     == 8 SAM output\n"
-		"                                     == 9 Family classification (ONLY for pfsearch)\n",
+		"                                     == 9 Family classification (ONLY for pfsearch)\n"
+		"                                     == 10 Turtle/RDF output for HAMAP as SPARQL style rules (pfsearch)\n",
 		stream);
 	fprintf(stream,
 		"   --output-length <uint>  [-W] : maximum number of column for sequence\n"
@@ -336,8 +337,8 @@ int main (int argc, char *argv[])
 						case 6: PrintFunction = &PrintxPSA; break;
 						case 7: PrintFunction = &PrintTSV; break;
 						case 8: PrintFunction = &PrintSAM; break;
-                        case 9: PrintFunction = &PrintTurtle; break;
-						case 10: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
+						case 9: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
+                        case 10: PrintFunction = &PrintTurtle; break;
 						default:
 							fputs("Unrecognized ouput method.\n", stderr);
 							exit(1);

--- a/src/C/prg/pfsearch.c
+++ b/src/C/prg/pfsearch.c
@@ -1547,7 +1547,8 @@ int main (int argc, char *argv[])
             printf("PREFIX faldo:<http://biohackathon.org/resource/faldo#>\n");
             printf("PREFIX signature:<htp://purl.uniprot.org/hamap/>\n");
             printf("PREFIX edam:<http://edamontology.org/>\n");
-            printf("PREFIX hamap:<http://hamap.expasy.org/rdf/>\n");
+            printf("PREFIX profile:<http://example.org/yourprofiledb/>\n");
+            printf("PREFIX hamap:<https://hamap.expasy.org/rdf/>\n");
         }
 
 

--- a/src/C/prg/pfsearch.c
+++ b/src/C/prg/pfsearch.c
@@ -336,7 +336,8 @@ int main (int argc, char *argv[])
 						case 6: PrintFunction = &PrintxPSA; break;
 						case 7: PrintFunction = &PrintTSV; break;
 						case 8: PrintFunction = &PrintSAM; break;
-						case 9: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
+                        case 9: PrintFunction = &PrintTurtle; break;
+						case 10: PrintFunction = (PrintFunctionPtr) &PrintClassification; break;
 						default:
 							fputs("Unrecognized ouput method.\n", stderr);
 							exit(1);

--- a/src/C/utils/output.c
+++ b/src/C/utils/output.c
@@ -747,6 +747,40 @@ void PrintPfscanLOpt(const struct Profile * const prf, const char * * const Alig
     }
 }
 
+void PrintTurtle(const struct Profile * const prf, const char * * const AlignedSequence,
+										 const struct Alignment * const alignment, char * const Header,
+                     const size_t SequenceLength, const float RAVE, const int N, const PrintInput_t * const extra)
+{ // replicates old pfscan with -l option output (e.g. L=0  32.064    9802 pos.       1 -     416 MF_00007|DNA primase DnaG [dnaG].)
+  // could be used by ps_scan.pl (>=1.87)
+    RawToNormalizedFunctionPtr RawToNormalizedFunction = prf->RawToNormalized;
+    const float * const restrict NormCoefs = prf->NormalizationCoefs;
+
+    for (unsigned int i=0; i<N; ++i) {
+        const float normtest = (RawToNormalizedFunction == NULL)
+                             ? 0.0f
+                             : RawToNormalizedFunction(alignment[i].Score, NormCoefs, RAVE, SequenceLength);
+        int level = -1;
+        for ( unsigned int j = 0; j < MAXC; j++ ) { // find match level
+            int icut = prf->CutOffData.Values[ j ].ICUT;
+            int mcle = prf->CutOffData.Values[ j ].MCLE;
+            if ( mcle == 0 && icut == 0 ) break;
+            if ( alignment[i].Score >= icut ) { level = mcle; break; }
+            level = mcle -1; // p.s. with -c option a match could have a score lower than the lowest defined level...
+        } // p.s. prf->CutOffData.Values follows CUT_OFF line order in profile src; highest level should come first...
+
+        fprintf(stdout, "yr:%s\n",
+                               // level,
+                               // normtest,
+                               // alignment[i].Score,
+                               // alignment[i].Region.Sequence.Begin,
+                               // alignment[i].Region.Sequence.End,
+                                prf->AC_Number
+                               // prf->Identification,
+                               // prf->Description
+                               );
+    }
+}
+
 void PrintSAM(const struct Profile * const prf, const char * * const AlignedSequence,
               const struct Alignment * const alignment, char * const Header,
               const size_t SequenceLength, const float RAVE, const int N, const PrintInput_t * const extra)

--- a/src/C/utils/output.c
+++ b/src/C/utils/output.c
@@ -787,7 +787,7 @@ void PrintTurtle(const struct Profile * const prf, const char * * const AlignedS
             _length = strlen(seqid);
         }
         fprintf(stdout, "yr:%.*s up:sequence ys:%.*s ;\n", _length, seqid, _length, seqid);
-        fprintf(stdout, "  rdfs:seeAlso profile:%s .\n[ edam:is_output_of [\n  a edam:operation_0300 ;\n  edam:has_input profile:%s \n  ] ;\n",
+        fprintf(stdout, "  rdfs:seeAlso profile:%s .\n[ a edam:data_0869 ; edam:is_output_of [\n  a edam:operation_0300 ;\n  edam:has_input profile:%s \n  ] ;\n",
                                 prf->AC_Number,
                                 prf->AC_Number
                                );

--- a/src/C/utils/output.c
+++ b/src/C/utils/output.c
@@ -767,7 +767,8 @@ void PrintTurtle(const struct Profile * const prf, const char * * const AlignedS
             level = mcle -1; // p.s. with -c option a match could have a score lower than the lowest defined level...
         } // p.s. prf->CutOffData.Values follows CUT_OFF line order in profile src; highest level should come first...
         const char *firstpipe = strchr(Header+1, '|');
-        const char * seqid;
+        const char *seqid;
+        const char *firstspace = strchr(Header+1, ' ');
         int _length;
         if (firstpipe != NULL) {
             const char *secondpipe = strchr(firstpipe+1, '|');
@@ -778,6 +779,9 @@ void PrintTurtle(const struct Profile * const prf, const char * * const AlignedS
                 seqid=firstpipe+1;
                 _length = strlen(seqid);
             }
+        } else if (firstspace != NULL) { // Cut of the ID at the first space
+            seqid=Header+1;
+            _length = (firstspace)-seqid;
         } else {
             seqid=Header+1;
             _length = strlen(seqid);

--- a/src/C/utils/output.c
+++ b/src/C/utils/output.c
@@ -791,7 +791,7 @@ void PrintTurtle(const struct Profile * const prf, const char * * const AlignedS
                                 prf->AC_Number,
                                 prf->AC_Number
                                );
-        fprintf(stdout, "  faldo:region [\n    faldo:begin [\n      faldo:position %d ;\n      faldo:reference ys:%.*s  ] ;\n    faldo:end [\n      faldo:position %d ;\n      faldo:reference ys:%.*s ] \n  ];\n  rdf:value",
+        fprintf(stdout, "  faldo:location [\n    faldo:begin [\n      faldo:position %d ;\n      faldo:reference ys:%.*s  ] ;\n    faldo:end [\n      faldo:position %d ;\n      faldo:reference ys:%.*s ] \n  ];\n  rdf:value",
                                 alignment[i].Region.Sequence.Begin,
                                 _length,
                                 seqid,

--- a/src/C/utils/output.c
+++ b/src/C/utils/output.c
@@ -787,7 +787,7 @@ void PrintTurtle(const struct Profile * const prf, const char * * const AlignedS
                                 prf->AC_Number,
                                 prf->AC_Number
                                );
-        fprintf(stdout, "  faldo:region [\n    faldo:begin [\n      faldo:position %d ;\n      faldo:reference ys:%.*s . ] ;\n    faldo:end [\n      faldo:position %d ;\n      faldo:reference ys:%.*s .] \n  ];\n  rdf:value",
+        fprintf(stdout, "  faldo:region [\n    faldo:begin [\n      faldo:position %d ;\n      faldo:reference ys:%.*s  ] ;\n    faldo:end [\n      faldo:position %d ;\n      faldo:reference ys:%.*s ] \n  ];\n  rdf:value",
                                 alignment[i].Region.Sequence.Begin,
                                 _length,
                                 seqid,
@@ -795,7 +795,7 @@ void PrintTurtle(const struct Profile * const prf, const char * * const AlignedS
                                 _length,
                                 seqid);
         
-        fprintf(stdout," '%s' . \n]\n", &AlignedSequence[i][1]);
+        fprintf(stdout," \"%s\" \n] .\n", &AlignedSequence[i][1]);
     }
 }
 

--- a/src/C/utils/output.c
+++ b/src/C/utils/output.c
@@ -767,26 +767,35 @@ void PrintTurtle(const struct Profile * const prf, const char * * const AlignedS
             level = mcle -1; // p.s. with -c option a match could have a score lower than the lowest defined level...
         } // p.s. prf->CutOffData.Values follows CUT_OFF line order in profile src; highest level should come first...
         const char *firstpipe = strchr(Header+1, '|');
+        const char * seqid;
+        int _length;
         if (firstpipe != NULL) {
             const char *secondpipe = strchr(firstpipe+1, '|');
             if (secondpipe != NULL) {
-                int _length = secondpipe - (firstpipe+1);
-//                 uint _length=6;
-                fprintf(stdout, "yr:%.*s up:sequence ys:%.*s ;", _length, firstpipe+1, _length, firstpipe+1);
+                _length = secondpipe - (firstpipe+1);
+                seqid=firstpipe+1;
             } else {
-                fprintf(stdout, "yr:%s up:sequence ys:%s ;", firstpipe+1, firstpipe+1);
+                seqid=firstpipe+1;
+                _length = strlen(seqid);
             }
         } else {
-            fprintf(stdout, "yr:%s up:sequence ys:%s ;", Header+1);
+            seqid=Header+1;
+            _length = strlen(seqid);
         }
-        fprintf(stdout, " rdfs:seeAlso profile:%s .\n[ edam:is_output_of [\n  a edam:operation_0300 ;\n  edam:has_input profile:%s \n  ] ;\n",
+        fprintf(stdout, "yr:%.*s up:sequence ys:%.*s ;\n", _length, seqid, _length, seqid);
+        fprintf(stdout, "  rdfs:seeAlso profile:%s .\n[ edam:is_output_of [\n  a edam:operation_0300 ;\n  edam:has_input profile:%s \n  ] ;\n",
                                 prf->AC_Number,
                                 prf->AC_Number
                                );
-        fprintf(stdout, "  faldo:region [ faldo:begin [ faldo:position %d ; ] ; faldo:end [ faldo:position %d ; ] ] ] \n",
+        fprintf(stdout, "  faldo:region [\n    faldo:begin [\n      faldo:position %d ;\n      faldo:reference ys:%.*s . ] ;\n    faldo:end [\n      faldo:position %d ;\n      faldo:reference ys:%.*s .] \n  ];\n  rdf:value",
                                 alignment[i].Region.Sequence.Begin,
-                                alignment[i].Region.Sequence.End
-                               );
+                                _length,
+                                seqid,
+                                alignment[i].Region.Sequence.End,
+                                _length,
+                                seqid);
+        
+        fprintf(stdout," '%s' . \n]\n", &AlignedSequence[i][1]);
     }
 }
 


### PR DESCRIPTION
This is a pull request to add turtle output to pftools that is useable for [HAMAP as SPARQL](https://www.biorxiv.org/content/10.1101/615294v1)

While this is still being worked on:

- [x] Turtle output added
- [x] Figure out how to define prefixes (new command line option?
- [x] Detect if profile is one from HAMAP and add right prefix.