### PR TITLE
Update ps_scan.pl: pfsearchV3 cutoff option

### DIFF
--- a/src/Perl/ps_scan.pl
+++ b/src/Perl/ps_scan.pl
@@ -2,7 +2,7 @@
 
 # ps_scan - a PROSITE scanning program
 #
-# Revision: 1.89
+# Revision: 1.90
 #
 # Copyright (C) 2001-2020 SIB Swiss Institute of Bioinformatics
 # Authors:
@@ -538,7 +538,7 @@ sub group_matches
 # initializations & parameters processing
 
 BEGIN {
-   $VERSION = '1.89';
+   $VERSION = '1.90';
 }
 
 # Can we use the IPC::Open2 module to communicate with
@@ -1722,7 +1722,7 @@ sub do_profile_scan {
             close DETECT;
         }
         @pre_command = ( $use_pfsearchV3 ?
-        	"$opt_pfsearch -o1 -c$cutoff $PROSITE" : "$opt_pfsearch $fasta -lxz $PROSITE" );
+        	"$opt_pfsearch -o1 -L $level_min $PROSITE" : "$opt_pfsearch $fasta -lxz $PROSITE" );
         	# p.s. if input is not fasta, pfsearchV3 will fail!
         @post_command = ( $use_pfsearchV3 ? "" : "C=$cutoff" );
     }


### PR DESCRIPTION
Fix: latest pfsearchV3 doesn't recognize -c option, it results in "Option ? is unknown" and aborts the pfsearchV3 run.
With earlier pfsearchV3, the -c option doesn't seem to have the expected effect, i.e. if ps_scan.pl is run with option "-l -1", the cut-off corresponding to the level -1 is put as argument to the -c but only matches with a score higher that the level 0 are retrieved.
Replacing the "-c$cutoff" by "-L $level_min" is valid for the latest pfsearchV3 and has the expected behavior regarding scores/levels for both the latest pfsearchV3 and earlier ones.