### PR TITLE
Fix issue #31 in wrprf.f: prevent WRITE overflow and improve numeric formatting

### DIFF
--- a/src/Fortran/wrprf.f
+++ b/src/Fortran/wrprf.f
@@ -264,14 +264,15 @@ C      Write(CPAR,'(''LENGTH='',I6,'';'')') LPRF
          Do  22 I2=1,KNOP
             ! Choose how to format RNOP(I2,I1) into CHRP(I2)
             ! Note: in Fortran .AND. has higher precedence than .OR.
-            ! if (|value| <= 10 and |value| > 1e-4) or value == 0.0 (exact)
-            ! => write fixed-point: width 10, 7 decimals
+            ! if (|value| <= 100 and |value| > 1e-4) or
+            ! value == 0.0 (exact)
+            ! => write fixed-point: width 12, 7 decimals
             ! else
             ! => write explicit format and 14 ≤ 16 → safe
-            If(ABS(RNOP(I2,I1)).LE.10.0
+            If(ABS(RNOP(I2,I1)).LE.100.0
      *         .AND.ABS(RNOP(I2,I1)).GT.0.0001
      *         .OR.RNOP(I2,I1).EQ.0.0) then
-               Write(CHRP(I2),'(F10.7)') RNOP(I2,I1)
+               Write(CHRP(I2),'(F12.7)') RNOP(I2,I1)
             Else
                ! was: Write(CHRP(I2),*) RNOP(I2,I1)
                Write(CHRP(I2),'(1PE14.6)') RNOP(I2,I1)

--- a/src/Fortran/wrprf.f
+++ b/src/Fortran/wrprf.f
@@ -267,13 +267,14 @@ C      Write(CPAR,'(''LENGTH='',I6,'';'')') LPRF
             ! if (|value| <= 10 and |value| > 1e-4) or value == 0.0 (exact)
             ! => write fixed-point: width 10, 7 decimals
             ! else
-            ! => write Fortran list-directed formatting (often scientific)
+            ! => write explicit format and 14 ≤ 16 → safe
             If(ABS(RNOP(I2,I1)).LE.10.0
      *         .AND.ABS(RNOP(I2,I1)).GT.0.0001
      *         .OR.RNOP(I2,I1).EQ.0.0) then
                Write(CHRP(I2),'(F10.7)') RNOP(I2,I1)
-            Else 
-               Write(CHRP(I2),*) RNOP(I2,I1)
+            Else
+               ! was: Write(CHRP(I2),*) RNOP(I2,I1)
+               Write(CHRP(I2),'(1PE14.6)') RNOP(I2,I1)
             End if
             ! Append "R<I2>=<formatted>; " into CPAR, starting at JP+1 (next free spot)
             Write(CPAR(JP+1:),*)'R',I2,'=',CHRP(I2),'; '


### PR DESCRIPTION
**Summary**

This PR addresses issue #31, which reported a possible internal WRITE overflow in wrprf.f when formatting RNOP(I2,I1) values into CHRP(I2) (CHARACTER*16).
The fix ensures safe and consistent output formatting while expanding the valid fixed-point range.

**Details of changes**
- Added explanatory comments
- Replaced list-directed internal WRITE with an explicit format (1PE14.6) for values outside the fixed-point range, guaranteeing a maximum width ≤ 16 characters and avoiding runtime overflow or core dump.
- Expanded the fixed-point range to |value| ≤ 100.0 (previously 10.0).

**Testing**

The fix was validated by compiling and running pfscale on a test set of 2,284 uncalibrated profiles.
- The modified code successfully calibrated all 2,284 profiles without any error.
- The unmodified code failed for most profiles, successfully calibrating only 276 out of 2,284.
- For the 276 profiles that were successfully calibrated by both versions, the resulting calibrated profiles were identical.

**Impact**
- Eliminates potential runtime overflow and improves reproducibility of numeric output.
- No change in semantics except for wider fixed-point coverage and slightly adjusted numeric field widths.